### PR TITLE
Changed the Website Link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,2 @@
-# Lab 2 - Starter
-The URL to the published site is: https://hurl365.github.io/Lab2_Starter/
+# Lab 3
+The URL to the new published site is: https://hurl365.github.io/fa22-cse110-lab3/


### PR DESCRIPTION
The link to Lab2's webpage is replaced by the link to Lab3's page now.